### PR TITLE
Added reset function to MessageBag

### DIFF
--- a/src/Entities/MessageBag.php
+++ b/src/Entities/MessageBag.php
@@ -78,6 +78,15 @@ class MessageBag
     }
 
     /**
+     * Resets the items and the xml data. Intended to be used to avoid the exception thrown by buildXml
+     * @return void
+     */
+    public function reset(){
+        $this->items = [];
+        $this->xml = null;
+    }
+
+    /**
      * Return the XML block for the Message Bag.
      * @return string The XML string.
      */


### PR DESCRIPTION
Couldn't find a way to properly get around the exception thrown by the buildXml() function when having multiple requests per page load (e.g. getting a UserID from Sentora then sending another request with the UserID as a parameter, or creating a user then creating a domain for that user). Hence the addition of the reset function.
